### PR TITLE
Show correctly escaped characters

### DIFF
--- a/src/clj/conference_rating/handler.clj
+++ b/src/clj/conference_rating/handler.clj
@@ -136,8 +136,8 @@
     (GET "/api/user/identity" request (utf-json-response (user-identity request)))
     (GET "/" [] (home-page api-key))))
 
-(defn update-conference [id body db]
-  (let [update-result (db/update-conference-by-id id body db)]
+(defn update-conference [id conference db]
+  (let [update-result (db/update-conference-by-id id (sanatize conference) db)]
     (utf-json-response update-result)))
 
 (defn add-attendance [conference-id request db]

--- a/src/clj/conference_rating/handler.clj
+++ b/src/clj/conference_rating/handler.clj
@@ -75,11 +75,11 @@
     (escape-html x)
     x))
 
-(defn- sanatize [m]
+(defn- sanitize [m]
   (walk/postwalk escape-string m))
 
 (s/defn add-conference [conference :- schemas/Conference db]
-  (let [add-result (db/add-conference (sanatize conference) db)
+  (let [add-result (db/add-conference (sanitize conference) db)
         id         (:_id add-result)]
     (created (str "/api/conferences/" id) add-result)))
 
@@ -95,7 +95,7 @@
 (def parse-rating (coerce/coercer schemas/Rating coerce/json-coercion-matcher))
 
 (defn add-rating [conference-id request db]
-  (let [complete (assoc (sanatize (:body request))
+  (let [complete (assoc (sanitize (:body request))
                    :conference-id conference-id
                    :user (user-identity request))
         rating (parse-rating complete)
@@ -137,7 +137,7 @@
     (GET "/" [] (home-page api-key))))
 
 (defn update-conference [id conference db]
-  (let [update-result (db/update-conference-by-id id (sanatize conference) db)]
+  (let [update-result (db/update-conference-by-id id (sanitize conference) db)]
     (utf-json-response update-result)))
 
 (defn add-attendance [conference-id request db]

--- a/src/cljs/conference_rating/backend.cljs
+++ b/src/cljs/conference_rating/backend.cljs
@@ -4,9 +4,10 @@
             [conference-rating.util :as util]))
 
 (defn- unsanitize [conference-data]
-  (assoc conference-data :name (util/unescape (:name conference-data))
-                         :series (util/unescape (:series conference-data))
-                         :description (util/unescape (:description conference-data))))
+  (let [location-escaped-data (assoc-in conference-data [:location :name] (util/unescape (:name (:location conference-data))))]
+    (assoc location-escaped-data :name (util/unescape (:name location-escaped-data))
+                         :series (util/unescape (:series location-escaped-data))
+                         :description (util/unescape (:description location-escaped-data)))))
 
 (defn ajaxless-load-conference [id success-handler ajax-fn]
   (ajax-fn (str "/api/conferences/" id) {:handler (fn [conference] (success-handler (unsanitize conference)))

--- a/src/cljs/conference_rating/backend.cljs
+++ b/src/cljs/conference_rating/backend.cljs
@@ -4,13 +4,18 @@
             [conference-rating.util :as util]))
 
 (defn- unsanitize [conference-data]
-  (assoc conference-data :description (util/unescape (:description conference-data))))
+  (assoc conference-data :name (util/unescape (:name conference-data))
+                         :series (util/unescape (:series conference-data))
+                         :description (util/unescape (:description conference-data))))
 
-(defn load-conference [id success-handler]
-  (ajax/GET (str "/api/conferences/" id) {:handler (fn [conference] (success-handler (unsanitize conference)))
+(defn ajaxless-load-conference [id success-handler ajax-fn]
+  (ajax-fn (str "/api/conferences/" id) {:handler (fn [conference] (success-handler (unsanitize conference)))
                                           :error-handler #(js/alert "Conference not found.")
                                           :response-format :json
                                           :keywords? true}))
+
+(defn load-conference [id success-handler]
+  (ajaxless-load-conference id success-handler ajax/GET))
 
 (defn load-conference-ratings [id success-handler]
   (ajax/GET (str "/api/conferences/" id "/ratings") {:handler success-handler
@@ -18,11 +23,14 @@
                                                      :response-format :json
                                                      :keywords? true}))
 
-(defn load-conferences [success-handler]
-  (ajax/GET "/api/conferences" {:handler success-handler
+(defn ajaxless-load-conferences [success-handler ajax-fn]
+  (ajax-fn "/api/conferences" {:handler (fn [conferences] (success-handler (map unsanitize conferences)))
                                 :error-handler #(js/alert "Conferences not found.")
                                 :response-format :json
                                 :keywords? true}))
+
+(defn load-conferences [success-handler]
+  (ajaxless-load-conferences success-handler ajax/GET))
 
 (defn load-series-suggestions [q success-handler]
   (ajax/GET (str "/api/series/suggestions?q=" q)

--- a/test/clj/conference_rating/functional_test.clj
+++ b/test/clj/conference_rating/functional_test.clj
@@ -95,7 +95,7 @@
         past-conference-link "www.some-link.org"
         past-conference-location-search-term "CCH - Congress Center"
         past-conference-location-name "CCH - Congress Center Hamburg"
-        past-conference-location-address "Am Dammtor / Marseiller Straße, 20355 Hamburg, Germany"
+        past-conference-location-address "Am Dammtor, Marseiller Str., 20355 Hamburg, Germany"
         past-conference-description "some really fancy description with a new line.\nAnd here is the new line. Wohooo!"
         future-conference-name (str "some other unique conference name" (UUID/randomUUID))]
 

--- a/test/clj/conference_rating/handler_test.clj
+++ b/test/clj/conference_rating/handler_test.clj
@@ -94,7 +94,7 @@
                   response (create-app-and-call db (-> (request :put (str "/api/conferences/" id "/edit"))
                                                        (body (json/write-str (some-conference-with {
                                                                                            :name "some other name"
-                                                                                           :description "some other description"})))
+                                                                                           :description "some other description with <tag> and &"})))
                                                        (header :content-type "application/json")))]
               (is (= 200 (:status response)))
               (is (= "application/json; charset=UTF-8" (get-content-type response)))
@@ -103,7 +103,7 @@
                 (is (= "application/json; charset=UTF-8" (get-content-type raw-response)))
                 (let [conference (json-body raw-response)]
                   (is (= "some other name" (:name conference)))
-                  (is (= "some other description" (:description conference))))))
+                  (is (= "some other description with &lt;tag&gt; and &amp;" (:description conference))))))
             (let [id (:_id (first conferences))
                   response (create-app-and-call db (request :delete (str "/api/conferences/" id)))]
               (is (= 204 (:status response))))))

--- a/test/cljs/conference_rating/backend_test.cljs
+++ b/test/cljs/conference_rating/backend_test.cljs
@@ -7,6 +7,11 @@
 (def sanitized-get-conference-response {:description "&lt;tag&gt;",
                          :series "test &amp; test",
                          :name  "/ / &amp; &amp;",
+                         :location {
+                               :lng 100.532159,
+                               :lat 13.7455534,
+                               :address "236/8-9 ซอย สยามสแควร์ 2 Khwaeng Pathum Wan, Khet Pathum Wan, Krung Thep Maha Nakhon 10330, Tailandia",
+                               :name "Growth cafe &amp; co."}
                          :link "www.com.com"})
 
 (defn mock-get-conference [endpoint request]
@@ -15,10 +20,20 @@
 (def sanitized-get-conferences-response [{:description "&lt;tag&gt;",
                                         :series "test &amp; test",
                                         :name  "/ / &amp; &amp;",
+                                        :location {
+                                                   :lng 100.532159,
+                                                   :lat 13.7455534,
+                                                   :address "236/8-9 ซอย สยามสแควร์ 2 Khwaeng Pathum Wan, Khet Pathum Wan, Krung Thep Maha Nakhon 10330, Tailandia",
+                                                   :name "Growth cafe &amp; co."}
                                         :link "www.com.com"}
                                          {:description "second &lt;",
                                           :series "test &amp; test",
                                           :name  "second &amp;",
+                                          :location {
+                                                     :lng 100.532159,
+                                                     :lat 13.7455534,
+                                                     :address "236/8-9 ซอย สยามสแควร์ 2 Khwaeng Pathum Wan, Khet Pathum Wan, Krung Thep Maha Nakhon 10330, Tailandia",
+                                                     :name "Growth cafe &amp; co."}
                                           :link "www.com.com"}])
 
 (defn mock-get-conferences [endpoint request]
@@ -29,6 +44,7 @@
                   (let [response (backend/ajaxless-load-conference "id" just-return-it mock-get-conference)]
                     (is (= "<tag>" (:description response)))
                     (is (= "test & test" (:series response)))
+                    (is (= "Growth cafe & co." (:name (:location response))))
                     (is (= "/ / & &" (:name response))))))
 
 (deftest load-several-conferences
@@ -37,10 +53,12 @@
                     (let [first-conf (get response 0)]
                       (is (= "<tag>" (:description first-conf)))
                       (is (= "test & test" (:series first-conf)))
+                      (is (= "Growth cafe & co." (:name (:location first-conf))))
                       (is (= "/ / & &" (:name first-conf))))
                     (let [second-conf (get response 1)]
                       (is (= "second <" (:description second-conf)))
                       (is (= "test & test" (:series second-conf)))
+                      (is (= "Growth cafe & co." (:name (:location second-conf))))
                       (is (= "second &" (:name second-conf)))))))
 
 

--- a/test/cljs/conference_rating/backend_test.cljs
+++ b/test/cljs/conference_rating/backend_test.cljs
@@ -1,0 +1,46 @@
+(ns conference-rating.backend_test
+  (:require [cemerick.cljs.test :refer-macros [is are deftest testing use-fixtures done]]
+            [conference-rating.backend :as backend]))
+
+(defn just-return-it [returned-conference] returned-conference)
+
+(def sanitized-get-conference-response {:description "&lt;tag&gt;",
+                         :series "test &amp; test",
+                         :name  "/ / &amp; &amp;",
+                         :link "www.com.com"})
+
+(defn mock-get-conference [endpoint request]
+  ((:handler request) sanitized-get-conference-response))
+
+(def sanitized-get-conferences-response [{:description "&lt;tag&gt;",
+                                        :series "test &amp; test",
+                                        :name  "/ / &amp; &amp;",
+                                        :link "www.com.com"}
+                                         {:description "second &lt;",
+                                          :series "test &amp; test",
+                                          :name  "second &amp;",
+                                          :link "www.com.com"}])
+
+(defn mock-get-conferences [endpoint request]
+  ((:handler request) sanitized-get-conferences-response))
+
+(deftest load-one-conference
+         (testing "should return unsanitized fields for a conference"
+                  (let [response (backend/ajaxless-load-conference "id" just-return-it mock-get-conference)]
+                    (is (= "<tag>" (:description response)))
+                    (is (= "test & test" (:series response)))
+                    (is (= "/ / & &" (:name response))))))
+
+(deftest load-several-conferences
+         (testing "should return unsanitized fields for several conferences"
+                  (let [response (into [] (backend/ajaxless-load-conferences just-return-it mock-get-conferences))]
+                    (let [first-conf (get response 0)]
+                      (is (= "<tag>" (:description first-conf)))
+                      (is (= "test & test" (:series first-conf)))
+                      (is (= "/ / & &" (:name first-conf))))
+                    (let [second-conf (get response 1)]
+                      (is (= "second <" (:description second-conf)))
+                      (is (= "test & test" (:series second-conf)))
+                      (is (= "second &" (:name second-conf)))))))
+
+


### PR DESCRIPTION
Now fixing [this issue](https://github.com/SteffiPeTaffy/conference-rating/issues/94) for real.

This escapes the creation and edition of conferences in the backend, and "un-escapes" them when received in the frontend.